### PR TITLE
Windows wimax fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,46 @@ Settings derived from [stata-exec](https://github.com/kylebarron/stata-exec), wh
 ### Linux
 Requirements for Linux are `xdotool` and `xclip` as in the Atom version
 
+### Windows 
+Installation instructions for Windows basically follows the original Atom [stata-exec](https://atom.io/packages/stata-exec) building manual with some modifications for `code`. 
+
+1. Install the `runStata` package. I also recommend the `Stata Enhanced` package for code highlighting.
+
+2. Install `Node`. The original instructions indicated to [install this specific version of Node](https://nodejs.org/dist/v7.4.0/node-v7.4.0-x64.msi) with default settings. I followed the instructions and haven't tried it with other versions.
+
+3. The `stataRun` extension needs a module called `wimax` to be compiled into a binary file. To do this `Node` needs `windows-build-tools` with Python2.7 and Visual Studio compiler packages. The installation takes some time (over 20 min. in my case) and couple of GB of disk space. To install it open up an administrator PowerShell (you can right click on the Windows icon at the bottom left and select "Windows PowerShell (Admin)") and type in:
+
+    ```
+    npm install --global --production windows-build-tools
+    ```
+    In my case the original command ended with an error, so I used this one with success:
+
+    ```
+    npm install --global --production windows-build-tools@2.2.1
+    ```
+4. Open up Command Prompt (type `cmd` in the search bar in the dock, and it will be the first result) and type in:
+
+    ```
+    cd %USERPROFILE%\.vscode\extensions\yeaoh.statarun-1.1.8
+    npm install winax --python=%USERPROFILE%\.windows-build-tools\python27\python.exe
+    ```
+    In `VSCode` go into `Help` -> `About`. From there save the Electron version. In the next command
+    replace `ELECTRON_VERSION` with the version from the `About` dialogue.
+
+    ```
+    npm rebuild winax --runtime=electron --target=ELECTRON_VERSION  --build-from-source
+    ```
+
+5. [Link the Stata Automation library](https://www.stata.com/automation/#install). The following steps worked for me on Windows 10. The Stata executable is most likely in the folder `C:\Program Files (x86)\Stata15`.
+
+    > 1. In the installation directory, right-click on the Stata executable, for example, StataSE.exe. Choose "Create Shortcut".
+    > 2. Right-click on the newly created "Shortcut to StataSE.exe", choose "Property", and change the Target from "C:\Program Files\Stata13\StataSE.exe" to "C:\Program Files\Stata13\StataSE.exe" /Register. Click "OK".
+    > 3. Right-click on the updated "Shortcut to StataSE.exe"; choose "Run as administrator"
+
+    While you're doing that, add the path of the Stata executable to the "Stata Path" option in the settings.
+
+6. Restart `code` and enjoy executing Stata code from `code`! (I hope...).
+
 ## Known Issues
 
 Only tested with Mac Os so far. Please and try create issues if any. Feel free to contributes.

--- a/sendCode.js
+++ b/sendCode.js
@@ -69,12 +69,11 @@ module.exports = {
 
     //spawn(config.get('stataPath'), { stdio: 'ignore', detached: true }).unref();
     //spawn(config.get('stataPath'));
-    const child = spawn(config.get('stataPath'), [], {
+    const child = spawn(config.get('stataPath'),[], {
       detached: true,
       stdio: 'ignore'
-    });
+    }).unref();
 
-    child.unref();
 
     return delay(2000)
       .then(() => {

--- a/sendCode.js
+++ b/sendCode.js
@@ -43,8 +43,8 @@ module.exports = {
   defineWinax(){
     console.log('requiring winax')
     const os = require('os');
-    var winaxPath = os.homedir();
-    winaxPath += "/.atom/packages/stataRun/node_modules/winax";
+    var winaxPath = vscode.extensions.getExtension("Yeaoh.stataRun").extensionPath;
+    winaxPath += "/node_modules/winax";
     try {
       return require(winaxPath);
     } catch (err) {
@@ -69,7 +69,7 @@ module.exports = {
 
     //spawn(config.get('stataPath'), { stdio: 'ignore', detached: true }).unref();
     //spawn(config.get('stataPath'));
-    const child = spawn(config.get('stataPath'), [text], {
+    const child = spawn(config.get('stataPath'), [], {
       detached: true,
       stdio: 'ignore'
     });


### PR DESCRIPTION
1. Added proper path to `wimax` module for Windows to fix #6 and #4 
2. Added building instructions for Windows based on Atom [stata-exec](https://atom.io/packages/stata-exec).
3. Modified code execution. 
Previously the code saved each command into a temporary do-file and executed them. Now if we send only a single line or the selection if less than 8192 chars long we send only the code filtered with comments removed.
If we send a whole file we just send the `do "`file"'` command to Stata.
If the file is an unsaved new file or we have a large selection we now write to the temp file and then execute it in Stata.