### PR TITLE
Add option to send Stata code to VS Code terminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,16 @@
                         "maximum": "10",
                         "default": "true",
                         "description": " This is only applicable for XQuartz. This value changes the amount of time the program waits between switching to the XQuartz window, pasting code, and sending enter'. The only way to send code to XQuartz is to use the clipboard, and the responsiveness of sending code will depend on the speed of your internet connection. If the copy-pasting isn't working, try increasing the value. Decreasing the value will run your code faster. Value must be between 0.1 and 10."
+                    },
+                    "stataRun.vscodeTerminal": {
+                        "type": "boolean",
+                        "default": "false",
+                        "description": "stataRun sends lines to built-in VS Code terminal window"
+                    },
+                    "stataRun.vscodeTerminalBin": {
+                        "type": "string",
+                        "default": "stata-se",
+                        "description": "Command to run when a terminal window is created"
                     }
                 }
             }

--- a/sendCode.js
+++ b/sendCode.js
@@ -28,6 +28,12 @@ module.exports = {
   send(text) {
     console.log('entering sendCode function');
     this.previousCommand = text;
+
+    var vsterm = config.get('vscodeTerminal');
+    if (vsterm == true) {
+      return this.sendTerminal(text)
+    }
+
     switch (process.platform) {
       case 'darwin':
         return this.sendMac(text);
@@ -183,5 +189,26 @@ module.exports = {
         console.error('code: ', text);
         return console.error('Applescript: ', cmd);
       });
+  },
+  sendTerminal(text) {
+    let activeTermOrNull = vscode.window.activeTerminal;
+
+    // let activeTerm = activeTermOrNull |
+    if (activeTermOrNull === null || activeTermOrNull === undefined) {
+      console.log("Not referencing any terminal and no terminal is open. Therefore creating new terminal.");
+      activeTermOrNull = vscode.window.createTerminal("StataRun");
+      activeTermOrNull.show(true);
+
+      var cmd = config.get('vscodeTerminalBin');
+      cmd += " " + text
+      activeTermOrNull.sendText(cmd, true);
+    }
+    else {
+      let activeTerm = activeTermOrNull;
+      activeTerm.show(true);
+      console.log(`StataRun|${text}`);
+      activeTerm.sendText(text, true);
+    }
   }
+
 };


### PR DESCRIPTION
Sometimes it is helpful to send the code directly to the VS Code terminal windows rather than a Stata application.

This commits adds support for the VS Code terminal as a target for StataRun.

This functionality is toggled through a new boolean option.

In case there is no active terminal window, StataRun will create a new window and open a new Stata session.